### PR TITLE
Add the default route metric

### DIFF
--- a/Netch/Controllers/TUNTAPController.cs
+++ b/Netch/Controllers/TUNTAPController.cs
@@ -140,7 +140,7 @@ namespace Netch.Controllers
 
                 Logging.Info("设置绕行规则 → 创建默认路由");
                 // 创建默认路由
-                if (!NativeMethods.CreateRoute("0.0.0.0", 0, Global.Settings.TUNTAP.Gateway, Global.TUNTAP.Index, 10))
+                if (!NativeMethods.CreateRoute("0.0.0.0", 0, Global.Settings.TUNTAP.Gateway, Global.TUNTAP.Index, 5))
                 {
                     State = Models.State.Stopped;
 


### PR DESCRIPTION
环境：Windows 7 旗舰版

由于默认路由权重与系统默认路由权重一致：

![image](https://user-images.githubusercontent.com/6874179/82867927-4b762e80-9f5e-11ea-911a-c02545d08c23.png)

导致Splashtop等软件的流量绕过了代理
