### PR TITLE
set mux to false by default

### DIFF
--- a/Netch/Models/Setting.cs
+++ b/Netch/Models/Setting.cs
@@ -68,7 +68,7 @@ namespace Netch.Models
 
         public KcpConfig KcpConfig = new KcpConfig();
 
-        public bool UseMux = true;
+        public bool UseMux = false;
     }
 
     public class AioDNSConfig

--- a/Netch/Servers/VMess/VMess.cs
+++ b/Netch/Servers/VMess/VMess.cs
@@ -70,7 +70,7 @@ namespace Netch.Servers.VMess
         /// <summary>
         ///		Mux 多路复用
         /// </summary>
-        public bool? UseMux { get; set; } = true;
+        public bool? UseMux { get; set; } = false;
     }
 
     public class VMessGlobal


### PR DESCRIPTION
I noticed that in
https://github.com/NetchX/Netch/pull/230
https://github.com/v2ray/v2ray-core/issues/2412
https://github.com/v2ray/v2ray-core/issues/2194
https://github.com/v2ray/v2ray-core/issues/1969
https://github.com/v2ray/v2ray-core/issues/1963
this has already been discussed that mux has some potential problems, 
although, there is a fix on this https://github.com/v2fly/v2ray-core/pull/168 , but it doesn't solve the problem completely.
so, i think it would be better if mux were set to false by default and use it at users' own risk.
