### PR TITLE
Changes V2rayN model, to avoid json parse error when v2ray updating subscription(s).

### DIFF
--- a/Netch/Servers/V2ray/Models/V2rayNSharing.cs
+++ b/Netch/Servers/V2ray/Models/V2rayNSharing.cs
@@ -13,7 +13,7 @@
         /// <summary>
         ///     额外 ID
         /// </summary>
-        public string aid { get; set; } = string.Empty;
+        public int aid { get; set; }
 
         /// <summary>
         ///     伪装域名（HTTP，WS）
@@ -38,7 +38,7 @@
         /// <summary>
         ///     端口
         /// </summary>
-        public string port { get; set; } = string.Empty;
+        public int port { get; set; }
 
         /// <summary>
         ///     备注

--- a/Netch/Servers/VMess/VMessUtil.cs
+++ b/Netch/Servers/VMess/VMessUtil.cs
@@ -1,13 +1,13 @@
-using System;
-using System.Collections.Generic;
-using System.Text.Encodings.Web;
-using System.Text.Json;
 using Netch.Controllers;
 using Netch.Models;
 using Netch.Servers.V2ray;
 using Netch.Servers.V2ray.Models;
 using Netch.Servers.VMess.Form;
 using Netch.Utils;
+using System;
+using System.Collections.Generic;
+using System.Text.Encodings.Web;
+using System.Text.Json;
 
 namespace Netch.Servers.VMess
 {
@@ -21,13 +21,13 @@ namespace Netch.Servers.VMess
 
         public string ShortName { get; } = "V2";
 
-        public string[] UriScheme { get; } = {"vmess"};
+        public string[] UriScheme { get; } = { "vmess" };
 
         public Type ServerType { get; } = typeof(VMess);
 
         public void Edit(Server s)
         {
-            new VMessForm((VMess) s).ShowDialog();
+            new VMessForm((VMess)s).ShowDialog();
         }
 
         public void Create()
@@ -39,22 +39,22 @@ namespace Netch.Servers.VMess
         {
             if (Global.Settings.V2RayConfig.V2rayNShareLink)
             {
-                var server = (VMess) s;
+                var server = (VMess)s;
 
                 var vmessJson = JsonSerializer.Serialize(new V2rayNSharing
-                    {
-                        v = "2",
-                        ps = server.Remark,
-                        add = server.Hostname,
-                        port = server.Port.ToString(),
-                        id = server.UserID,
-                        aid = server.AlterID.ToString(),
-                        net = server.TransferProtocol,
-                        type = server.FakeType,
-                        host = server.Host,
-                        path = server.Path,
-                        tls = server.TLSSecureType
-                    },
+                {
+                    v = "2",
+                    ps = server.Remark,
+                    add = server.Hostname,
+                    port = server.Port,
+                    id = server.UserID,
+                    aid = server.AlterID,
+                    net = server.TransferProtocol,
+                    type = server.FakeType,
+                    host = server.Host,
+                    path = server.Path,
+                    tls = server.TLSSecureType
+                },
                     new JsonSerializerOptions
                     {
                         Encoder = JavaScriptEncoder.UnsafeRelaxedJsonEscaping
@@ -89,9 +89,9 @@ namespace Netch.Servers.VMess
 
             data.Remark = vmess.ps;
             data.Hostname = vmess.add;
-            data.Port = ushort.Parse(vmess.port);
+            data.Port = (ushort)(vmess.port);
             data.UserID = vmess.id;
-            data.AlterID = int.Parse(vmess.aid);
+            data.AlterID = vmess.aid;
             data.TransferProtocol = vmess.net;
             data.FakeType = vmess.type;
 
@@ -112,7 +112,7 @@ namespace Netch.Servers.VMess
             data.TLSSecureType = vmess.tls;
             data.EncryptMethod = "auto"; // V2Ray 加密方式不包括在链接中，主动添加一个
 
-            return new[] {data};
+            return new[] { data };
         }
 
         public bool CheckServer(Server s)


### PR DESCRIPTION
订阅的时候会报错，是Newtonsoft JSON解析报类型不匹配错误，把模型类中的类型从string改为int便不再报错。