### PR TITLE
Try to fix #837

### DIFF
--- a/Netch/Servers/V2ray/V2rayConfig.cs
+++ b/Netch/Servers/V2ray/V2rayConfig.cs
@@ -81,6 +81,8 @@ public class ShadowsocksServerItem
     public string method { get; set; }
 
     public string password { get; set; }
+
+    public string flow { get; set; }
  }
 
 public class Mux

--- a/Netch/Servers/V2ray/V2rayConfigUtils.cs
+++ b/Netch/Servers/V2ray/V2rayConfigUtils.cs
@@ -83,7 +83,7 @@ public static class V2rayConfigUtils
                             new User
                             {
                                 id = vless.UserID,
-                                flow = vless.Flow.ValueOrDefault(),
+                                flow = vless.TLSSecureType == "xtls" ? "xtls-rprx-direct" : "",
                                 encryption = vless.EncryptMethod
                             }
                         }
@@ -195,6 +195,7 @@ public static class V2rayConfigUtils
                                 address = await server.AutoResolveHostnameAsync(),
                                 port = server.Port,
                                 method = "",
+                                flow = trojan.TLSSecureType == "xtls" ? "xtls-rprx-direct" : "",
                                 password = trojan.Password
                             }
                     }

--- a/Netch/Servers/V2ray/V2rayUtils.cs
+++ b/Netch/Servers/V2ray/V2rayUtils.cs
@@ -55,8 +55,6 @@ public static class V2rayUtils
             if (server.TLSSecureType != "none")
             {
                 server.ServerName = parameter.Get("sni") ?? "";
-                if (server.TLSSecureType == "xtls")
-                    ((VLESSServer)server).Flow = "xtls-rprx-direct"; // splice doesn't support Windows
             }
         }
 
@@ -137,9 +135,7 @@ public static class V2rayUtils
 
             if (server.TLSSecureType == "xtls")
             {
-                var flow = ((VLESSServer)server).Flow;
-                if (!flow.IsNullOrWhiteSpace())
-                    parameter.Add("flow", flow!.Replace("-udp443", ""));
+                parameter.Add("flow", "xtls-rprx-direct");
             }
         }
 

--- a/Netch/Servers/VLESS/VLESSForm.cs
+++ b/Netch/Servers/VLESS/VLESSForm.cs
@@ -17,7 +17,6 @@ internal class VLESSForm : ServerForm
             s => server.EncryptMethod = !string.IsNullOrWhiteSpace(s) ? s : "none",
             server.EncryptMethod);
 
-        CreateTextBox("Flow", "Flow", s => true, s => server.Flow = s, server.Flow);
         CreateComboBox("TransferProtocol",
             "Transfer Protocol",
             VLESSGlobal.TransferProtocols,

--- a/Netch/Servers/VLESS/VLESSServer.cs
+++ b/Netch/Servers/VLESS/VLESSServer.cs
@@ -18,10 +18,6 @@ public class VLESSServer : VMessServer
     ///     伪装类型
     /// </summary>
     public override string FakeType { get; set; } = VLESSGlobal.FakeTypes[0];
-
-    /// <summary>
-    /// </summary>
-    public string? Flow { get; set; } = "xtls-rprx-direct";
 }
 
 public class VLESSGlobal


### PR DESCRIPTION
When not using XTLS, filling any string in the flow will cause to fail, but will not crash.  
This PR fixes flow problem and removes useless flow item parameter from GUI form.  
  
Best regards,  
Hellojack.