### PR TITLE
fix a bug that when using socks5 with authentication, username and pa…

### DIFF
--- a/Redirector/SocksHelper.cpp
+++ b/Redirector/SocksHelper.cpp
@@ -89,10 +89,10 @@ bool SocksHelper::Handshake(SOCKET client)
 		}
 
 		/* Password */
-		buffer[1 + plength] = 0x00;
+		buffer[1 + 1 + ulength] = 0x00;
 		if (plength != 0)
 		{
-			buffer[1 + ulength] = plength;
+			buffer[1 + 1 + ulength] = plength;
 			memcpy(buffer + 1 + 1 + ulength + 1, tgtPassword.c_str(), plength);
 		}
 


### PR DESCRIPTION
fix a bug that when using socks5 with authentication, username and password can't sent to server correctly
as [RFC 1929](https://datatracker.ietf.org/doc/html/rfc1929) said, auth packet should be 
```
           +----+------+----------+------+----------+
           |VER | ULEN |  UNAME   | PLEN |  PASSWD  |
           +----+------+----------+------+----------+
           | 1  |  1   | 1 to 255 |  1   | 1 to 255 |
           +----+------+----------+------+----------+
```
current behaviour(both build from source and [1.9.6](https://github.com/netchx/netch/releases/tag/1.9.6)): 
PLEN was set on a wrong offset, makes UNAME interrupted, PLEN and PASSWD was advanced by one byte. For example, server([dante](http://www.inet.no/dante/index.html) v1.4.3) received username "Lip(" instead of "Lipi" as password was "D3AED7CBDXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX" (a meaningless 40 bytes length hex string)
behaviour after fix: socks5 with authentication works as expected