### PR TITLE
'Mode' json improve 优化内置的"模式(json)"的多语言显示

### DIFF
--- a/Storage/mode/Game/Age of Empires IV.json
+++ b/Storage/mode/Game/Age of Empires IV.json
@@ -1,7 +1,10 @@
 {
   "type": "ProcessMode",
   "remark": {
-    "zh-CN": "Age of Empires IV"
+    "zh-CN": "Age of Empires IV",
+    "zh-TW": "Age of Empires IV",
+    "en-US": "Age of Empires IV",
+    "ja-JP": "Age of Empires IV"
   },
   "handle": [
     "RelicCardinal_ws.exe"

--- a/Storage/mode/Game/COD18.json
+++ b/Storage/mode/Game/COD18.json
@@ -1,7 +1,10 @@
 {
   "type": "ProcessMode",
   "remark": {
-    "zh-CN": "COD18"
+    "zh-CN": "COD18",
+    "en-US": "COD18",
+    "ja-JP": "COD18",
+    "zh-TW": "COD18"
   },
   "handle": [
     "\\\\Battlestate Games\\\\",

--- a/Storage/mode/Game/PVZ Battle for Neighborville.json
+++ b/Storage/mode/Game/PVZ Battle for Neighborville.json
@@ -1,7 +1,10 @@
 {
   "type": "ProcessMode",
   "remark": {
-    "zh-CN": "PVZ Battle for Neighborville"
+    "zh-CN": "PVZ Battle for Neighborville",
+    "zh-TW": "PVZ Battle for Neighborville",
+    "en-US": "PVZ Battle for Neighborville",
+    "ja-JP": "PVZ Battle for Neighborville"
   },
   "handle": [
     "PVZ Battle for Neighborville"

--- a/Storage/mode/Global.json
+++ b/Storage/mode/Global.json
@@ -1,7 +1,10 @@
 {
   "type": "ProcessMode",
   "remark": {
-    "zh-CN": "Global"
+    "zh-CN": "Global",
+    "zh-TW": "Global",
+    "en-US": "Global",
+    "ja-JP": "Global"
   },
   "handle": [
     ".*"

--- a/Storage/mode/Other/NVIDIA Corporation.json
+++ b/Storage/mode/Other/NVIDIA Corporation.json
@@ -1,7 +1,10 @@
 {
   "type": "ProcessMode",
   "remark": {
-    "zh-CN": "NVIDIA Corporation"
+    "zh-CN": "NVIDIA Corporation",
+    "zh-TW": "NVIDIA Corporation",
+    "en-US": "NVIDIA Corporation",
+    "ja-JP": "NVIDIA Corporation"
   },
   "handle": [
     "\\\\NVIDIA Corporation\\\\"


### PR DESCRIPTION
JSON格式的模式配置文件, 在netch中的显示名是根据设置的语言显示的, 但在创建模式的时候只会写入当前语言的显示名...
因此JSON的配置文件在别的语言下就会显示为空.

在我创建json中有这样的字段
"remark":{
"zh-CN": "A Snowbreak",
"zh-CN.txt": "A snowbreak",
"zh-TW.txt": "A snowbreak",
"zh-TW": "A snowbreak"
}
带txt后缀的是我自己引入的语言文件