### PR TITLE
Fix potential deadlock in WaitGroup

### DIFF
--- a/RouteHelper/WaitGroup.cpp
+++ b/RouteHelper/WaitGroup.cpp
@@ -8,7 +8,10 @@ void WaitGroup::Add(int size)
 void WaitGroup::Done()
 {
 	if (--this->counter <= 0)
+	{
+		std::scoped_lock lock(this->mutex);
 		this->condition.notify_all();
+	}
 }
 
 void WaitGroup::Wait()


### PR DESCRIPTION
1. `Wait` routine checks for condition, which is not true
2. `Done` routine updates the counter to zero and notifies, but no one listens
3. `Wait` routine subscribes to condvar but it's too late and it will only wake up after another `Done` or a spurious wakeup