### PR TITLE
feat: Add xhttp, reality, and build script

### DIFF
--- a/Netch/Servers/VLESS/VLESSServer.cs
+++ b/Netch/Servers/VLESS/VLESSServer.cs
@@ -26,7 +26,8 @@ public class VLESSGlobal
     {
         "none",
         "tls",
-        "xtls"
+        "xtls",
+        "reality"
     };
 
     public static List<string> FakeTypes => VMessGlobal.FakeTypes;

--- a/Netch/Servers/VMess/VMessServer.cs
+++ b/Netch/Servers/VMess/VMessServer.cs
@@ -137,7 +137,8 @@ public class VMessGlobal
         "ws",
         "h2",
         "quic",
-        "grpc"
+        "grpc",
+        "xhttp"
     };
 
     /// <summary>

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+dotnet build Netch.sln


### PR DESCRIPTION
Adds `xhttp` to the list of transfer protocols and `reality` to the list of TLS secure options. Also adds a `build.sh` script to compile the application.

Note: This commit only adds the UI options for `xhttp` and `reality`. The underlying logic to handle these protocols is not yet implemented.